### PR TITLE
Update API for obsolete methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.meta
 Standard Assets
 Materials
+/.vs/slnx.sqlite-journal
+/.vs/slnx.sqlite
+/.vs/UnityVOXFileImport/FileContentIndex/read.lock
+/.vs/UnityVOXFileImport/FileContentIndex/a3837b48-a2f8-4f3f-9200-cc9409dc7f75.vsidx
+/.vs/UnityVOXFileImport/FileContentIndex/90c58a4e-188c-4fdc-8685-996b8a5fcc0d.vsidx

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 *.meta
 Standard Assets
 Materials
-/.vs/slnx.sqlite-journal
-/.vs/slnx.sqlite
-/.vs/UnityVOXFileImport/FileContentIndex/read.lock
-/.vs/UnityVOXFileImport/FileContentIndex/a3837b48-a2f8-4f3f-9200-cc9409dc7f75.vsidx
-/.vs/UnityVOXFileImport/FileContentIndex/90c58a4e-188c-4fdc-8685-996b8a5fcc0d.vsidx
+.vs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Features:
 
 Requirements:
 ========
-* Unity 2017.2.0 or higher
+* Unity 2018.3.0 or higher
 
 Contact:
 ------------

--- a/VOXFileLoader/Scripts/VOXFileImport.cs
+++ b/VOXFileLoader/Scripts/VOXFileImport.cs
@@ -570,7 +570,7 @@ namespace Cubizer
 					gameObject = LoadVoxelFileAsGameObject(name, voxel, lodLevel);
 
 					var prefabPath = path + name + ".prefab";
-					var prefab = PrefabUtility.SaveAsPrefabAsset(new GameObject(), prefabPath);
+					var prefab = PrefabUtility.SaveAsPrefabAsset(gameObject, prefabPath);
 					var prefabTextures = new Dictionary<string, int>();
 
 					for (int i = 0; i < gameObject.transform.childCount; i++)
@@ -601,7 +601,7 @@ namespace Cubizer
 						}
 					}
 
-					return PrefabUtility.SaveAsPrefabAssetAndConnect(gameObject, prefabPath, InteractionMode.AutomatedAction);
+					return PrefabUtility.SaveAsPrefabAsset(gameObject, prefabPath);
 				}
 				finally
 				{

--- a/VOXFileLoader/Scripts/VOXFileImport.cs
+++ b/VOXFileLoader/Scripts/VOXFileImport.cs
@@ -570,7 +570,7 @@ namespace Cubizer
 					gameObject = LoadVoxelFileAsGameObject(name, voxel, lodLevel);
 
 					var prefabPath = path + name + ".prefab";
-					var prefab = PrefabUtility.CreateEmptyPrefab(prefabPath);
+					var prefab = PrefabUtility.SaveAsPrefabAsset(new GameObject(), prefabPath);
 					var prefabTextures = new Dictionary<string, int>();
 
 					for (int i = 0; i < gameObject.transform.childCount; i++)
@@ -601,7 +601,7 @@ namespace Cubizer
 						}
 					}
 
-					return PrefabUtility.ReplacePrefab(gameObject, prefab, ReplacePrefabOptions.ReplaceNameBased);
+					return PrefabUtility.SaveAsPrefabAssetAndConnect(gameObject, prefabPath, InteractionMode.AutomatedAction);
 				}
 				finally
 				{
@@ -614,7 +614,6 @@ namespace Cubizer
 				var voxel = VoxFileImport.Load(path);
 				return LoadVoxelFileAsPrefab(voxel, Path.GetFileNameWithoutExtension(path), outpath, lodLevel);
 			}
-
 #endif
 		}
 	}


### PR DESCRIPTION
- Fix editor complaints of obsolute methods by using more recents Prefab API, this also makes minium required version to be ^2018.3